### PR TITLE
Simplified loading and caching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,21 +2,27 @@ Kalpa
 #####
 
 Kalpa provides a starting point for resource traversal in Pyramid. It provides
-two classes for this, a `Branch` and a `Leaf`, which allow you to create
-arbitrary resource trees without the boilerplate.
+two classes for this, a :code:`Branch` and a :code:`Leaf`, which allow you to
+create arbitrary resource trees without the boilerplate.
+
+There is also a :code:`Root` class for added convenience that accepts a
+request during initialization. This can be used to create a starting point for
+Pyramid's traversal.
 
 .. code-block:: python
 
     from kalpa import Root, Branch, Leaf
 
-    from . import model
+    USERS = {...}
+
 
     @Root.attach('users')
     class UserCollection(Branch):
-        """User collection, for listings or loading specific ones."""
-        def __getitem__(self, key):
-            # Load user with SQLAlchemy session available on request
-            user = self.request.db.query(model.User).get(key)
+        """User collection, for listings, or loading single users."""
+
+        def __load__(self, path):
+            """Return child resource with requested user included."""
+            user = USERS[path]  # Load user or raise KeyError.
             return self._sprout(key, user=user)
 
 
@@ -25,6 +31,9 @@ arbitrary resource trees without the boilerplate.
         """User resource, a single loaded user."""
 
 
-    @User.attach('images')
-    class UserImageCollection(Leaf):
-        """Collection of images posted by a user."""
+    @User.attach('gallery', aliases=['images'])
+    class UserGallery(Leaf):
+        """Gallery of images posted by a user.
+
+        Reachable as `/users/:id/gallery` but also `/users/:id/images`.
+        """

--- a/kalpa/tests/test_kalpa.py
+++ b/kalpa/tests/test_kalpa.py
@@ -44,12 +44,12 @@ def branching_tree():
 
     @Root.attach('objects')
     class Collection(kalpa.Branch):
-        def __getitem__(self, path):
+        def __load__(self, path):
             return self._sprout(path, fruit='apple', twice=path * 2)
 
     @Root.attach('people')
     class People(kalpa.Branch):
-        def __getitem__(self, path):
+        def __load__(self, path):
             return self._sprout_resource(Person, path, first=path[0].upper())
 
     @Collection.child_resource

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ README = open(os.path.join(HERE, 'README.rst')).read()
 
 setup(
     name='kalpa',
-    version='0.1',
+    version='0.2',
     author='Elmer de Looff',
     author_email='elmer.delooff@gmail.com',
     description='Resource baseclasses for traversal in Pyramid ',
@@ -19,7 +19,7 @@ setup(
     url='http://variable-scope.com',
     keywords='pyramid traversal resource helper',
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 2 - Alpha',
         'Framework :: Pyramid',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
This simplifies the work necessary for implementers to set up dynamic loading, and resolves #1. Instead of overriding `__getitem__` and having to manually cache the loaded resource, loading of resources is done using a separate `__load__` method, and the unchanged `__getitem__` method takes care of the caching.

This approach also makes it possible to statically attach resources to a `Branch` class that also performs dynamic retrieval of resources. Traversal of a `Branch` class will:

1. Return a cached resource is one was set, ensuring Pyramid location functions behave as expected
2. Return a statically attached resource if one was registered
3. Return dynamically load a resource using `__load__`
4. Raise `KeyError` (the default behavior or the dynamic loader method)