### PR TITLE
Test improvements and integration

### DIFF
--- a/kalpa/tests/test_kalpa.py
+++ b/kalpa/tests/test_kalpa.py
@@ -1,13 +1,30 @@
-#!/usr/bin/python
-
 import pytest
 from pyramid import location
 
-import kalpa
+
+@pytest.fixture
+def kalpa_root():
+    """Imports and returns kalpa Root class."""
+    from kalpa import Root
+    return Root
 
 
 @pytest.fixture
-def basic_tree():
+def kalpa_branch():
+    """Imports and returns kalpa Branch class."""
+    from kalpa import Branch
+    return Branch
+
+
+@pytest.fixture
+def kalpa_leaf():
+    """Imports and returns kalpa Leaf class."""
+    from kalpa import Leaf
+    return Leaf
+
+
+@pytest.fixture
+def basic_tree(kalpa_root, kalpa_leaf):
     """A simple root resource with a single static sub-resource.
 
     This implicitly tests the following components:
@@ -15,11 +32,11 @@ def basic_tree():
         - Static resource class attachment
         - Aliased resource attachment
     """
-    class Root(kalpa.Root):
+    class Root(kalpa_root):
         pass
 
     @Root.attach('leaf', aliases=['foliage', 'leaves'])
-    class Leaf(kalpa.Leaf):
+    class Leaf(kalpa_leaf):
         pass
 
     return {
@@ -29,7 +46,7 @@ def basic_tree():
 
 
 @pytest.fixture
-def branching_tree():
+def branching_tree(kalpa_root, kalpa_branch, kalpa_leaf):
     """Returns a resource tree which is used for dynamic resource loading.
 
     This implicitly tests the following parts of kalpa:
@@ -39,28 +56,28 @@ def branching_tree():
         - Child resource creation using the registered class
         - Child resource creation using a specified class
     """
-    class Root(kalpa.Root):
+    class Root(kalpa_root):
         pass
 
     @Root.attach('objects')
-    class Collection(kalpa.Branch):
+    class Collection(kalpa_branch):
         def __load__(self, path):
             return self._sprout(path, fruit='apple', twice=path * 2)
 
     @Root.attach('people')
-    class People(kalpa.Branch):
+    class People(kalpa_branch):
         def __load__(self, path):
             return self._sprout_resource(Person, path, first=path[0].upper())
 
     @Collection.child_resource
-    class Object(kalpa.Branch):
+    class Object(kalpa_branch):
         pass
 
     @Object.attach('votes')
-    class Votes(kalpa.Leaf):
+    class Votes(kalpa_leaf):
         pass
 
-    class Person(kalpa.Leaf):
+    class Person(kalpa_leaf):
         pass
 
     return {
@@ -73,7 +90,7 @@ def branching_tree():
 
 
 @pytest.fixture
-def mixed_tree():
+def mixed_tree(kalpa_root, kalpa_leaf):
     """Returns a resource tree which has mixed resource loading.
 
     This implicitly tests the following parts of kalpa:
@@ -82,17 +99,17 @@ def mixed_tree():
         - Child resource assignment to Branch classes
         - Child resource creation using the registered class
     """
-    class Root(kalpa.Root):
+    class Root(kalpa_root):
         def __load__(self, path):
             return self._sprout(path)
 
     @Root.attach('spam')
     @Root.attach('eggs')
-    class Static(kalpa.Leaf):
+    class Static(kalpa_leaf):
         pass
 
     @Root.child_resource
-    class Dynamic(kalpa.Leaf):
+    class Dynamic(kalpa_leaf):
         pass
 
     return {

--- a/kalpa/tests/test_kalpa.py
+++ b/kalpa/tests/test_kalpa.py
@@ -1,5 +1,4 @@
 import pytest
-from pyramid import location
 
 
 @pytest.fixture
@@ -21,6 +20,13 @@ def kalpa_leaf():
     """Imports and returns kalpa Leaf class."""
     from kalpa import Leaf
     return Leaf
+
+
+@pytest.fixture
+def location_inside():
+    """Imports and returns `inside` function from Pyramid's location module."""
+    from pyramid.location import inside
+    return inside
 
 
 @pytest.fixture
@@ -126,11 +132,11 @@ class TestBasicResource(object):
         leaf = root['leaf']
         assert isinstance(leaf, basic_tree['leaf_cls'])
 
-    def test_sub_resource_lineage(self, basic_tree):
+    def test_sub_resource_lineage(self, basic_tree, location_inside):
         """Leaf is a child resource of Root according to Pyramid lineage."""
         root = basic_tree['root']
         leaf = root['leaf']
-        assert location.inside(leaf, root)
+        assert location_inside(leaf, root)
 
     def test_keyerror_for_nonexistant_sub_resource(self, basic_tree):
         root = basic_tree['root']
@@ -195,19 +201,19 @@ class TestBranchingResource(object):
         leaf = root['people']['alice']
         assert isinstance(leaf, branching_tree['person_cls'])
 
-    def test_object_lineage(self, branching_tree):
+    def test_object_lineage(self, branching_tree, location_inside):
         """Objects from collection is in lineage of Root and Collection."""
         root = branching_tree['root']
         leaf = root['objects']['any']
-        assert location.inside(leaf, root)
-        assert location.inside(leaf, root['objects'])
+        assert location_inside(leaf, root)
+        assert location_inside(leaf, root['objects'])
 
-    def test_alternate_object_lineage(self, branching_tree):
+    def test_alternate_object_lineage(self, branching_tree, location_inside):
         """Objects from collection is in lineage of Root and Collection."""
         root = branching_tree['root']
         leaf = root['people']['bob']
-        assert location.inside(leaf, root)
-        assert location.inside(leaf, root['people'])
+        assert location_inside(leaf, root)
+        assert location_inside(leaf, root['people'])
 
     def test_object_caching(self, branching_tree):
         """Retrieving the same object twice should provide the same one."""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = kalpa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[aliases]
+dev = develop easy_install kalpa[test]
+test = pytest

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,11 @@ from setuptools import (
     find_packages,
     setup)
 
-HERE = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(HERE, 'README.rst')).read()
+
+def contents(filename):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(here, filename)) as fp:
+        return fp.read()
 
 
 setup(
@@ -15,7 +18,7 @@ setup(
     author='Elmer de Looff',
     author_email='elmer.delooff@gmail.com',
     description='Resource baseclasses for traversal in Pyramid ',
-    long_description=README,
+    long_description=contents('README.rst'),
     url='http://variable-scope.com',
     keywords='pyramid traversal resource helper',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    tests_require=[
-        'pytest']
+    extras_require={
+        'test': ['pyramid', 'pytest-runner', 'pytest']
+    },
 )


### PR DESCRIPTION
* Makes testing more robust by stuffing imports away in fixtures, ensuring all tests run always, even if imports fail
* Added setuptools alias for installing package in develop mode and include test requirements (`python setup.py dev`)
* Added a second alias to make the setuptools `test` command work as expected