### PR TITLE
Subpath registry improvement

### DIFF
--- a/kalpa/__init__.py
+++ b/kalpa/__init__.py
@@ -92,12 +92,9 @@ class Branch(with_metaclass(BranchType, Leaf)):
     @classmethod
     def attach(cls, canonical_path, aliases=()):
         """Adds a resource as the child of another resource."""
-        paths = [canonical_path]
-        paths.extend(aliases)
-
         def _attach_resource(child_cls):
             """Stores the sub-resource on all relevant paths."""
-            for path in paths:
+            for path in [canonical_path] + list(aliases):
                 cls._SUBPATHS[path] = child_cls, canonical_path
             return child_cls
         return _attach_resource

--- a/kalpa/__init__.py
+++ b/kalpa/__init__.py
@@ -1,6 +1,8 @@
 """Kalpa provides base classes for Pyramid's traversal mechanism."""
 
-from six import iteritems
+from six import (
+    iteritems,
+    with_metaclass)
 
 
 class Leaf(object):
@@ -33,11 +35,16 @@ class Leaf(object):
         return '<{}>'.format(type(self).__name__)
 
 
-class Branch(Leaf):
-    """Base resource class for a branch, extends Leaf."""
-    _CHILD_CLS = None
-    _SUBPATHS = None
+class BranchType(type):
+    """Provide each class with its own unshared subpath registry."""
+    def __init__(cls, name, bases, namespace):
+        super(BranchType, cls).__init__(name, bases, namespace)
+        cls._CHILD_CLS = None
+        cls._SUBPATHS = {}
 
+
+class Branch(with_metaclass(BranchType, Leaf)):
+    """Base resource class for a branch, extends Leaf."""
     def __init__(self, _name, _parent, **attributes):
         super(Branch, self).__init__(_name, _parent, **attributes)
         self.__children__ = {}
@@ -85,8 +92,6 @@ class Branch(Leaf):
     @classmethod
     def attach(cls, canonical_path, aliases=()):
         """Adds a resource as the child of another resource."""
-        if cls._SUBPATHS is None:
-            cls._SUBPATHS = {}
         paths = [canonical_path]
         paths.extend(aliases)
 

--- a/kalpa/tests/test_kalpa.py
+++ b/kalpa/tests/test_kalpa.py
@@ -324,3 +324,9 @@ class TestPyramidTraversalIntegration(object):
         for path in ('leaf', 'leaves', 'foliage'):
             resource = traversal.find_resource(root, (path,))
             assert traversal.resource_path(resource) == '/leaf'
+
+
+def test_separate_subpath_registries(basic_tree, branching_tree):
+    basic_root = basic_tree['root_cls']
+    branching_root = branching_tree['root_cls']
+    assert basic_root._SUBPATHS is not branching_root._SUBPATHS

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def contents(filename):
 
 setup(
     name='kalpa',
-    version='0.2',
+    version='0.3',
     packages=find_packages(),
     author='Elmer de Looff',
     author_email='elmer.delooff@gmail.com',


### PR DESCRIPTION
This PR cleans up the `@attach` decorator, removing from it the conditional assignment of the `_SUBPATHS` dictionary, by moving that to a simple metaclass used to create `Branch` classes.

It also adds a test to explicitly test that subpath registries are not shared between classes.