### PR TITLE
Extract caching behavior

### DIFF
--- a/kalpa/__init__.py
+++ b/kalpa/__init__.py
@@ -49,10 +49,6 @@ class Branch(with_metaclass(BranchType, Leaf)):
         super(Branch, self).__init__(_name, _parent, **attributes)
         self.__children__ = {}
 
-    def __contains__(self, path):
-        """Returns whether or not the provided path is in the child cache."""
-        return path in self.__children__
-
     def __getitem__(self, path):
         """Returns a cached child resource or returns a newly created one.
 

--- a/kalpa/__init__.py
+++ b/kalpa/__init__.py
@@ -4,6 +4,8 @@ from six import (
     iteritems,
     with_metaclass)
 
+from .util import memoize
+
 
 class Leaf(object):
     """Base resource class for an end-node."""
@@ -45,10 +47,8 @@ class BranchType(type):
 
 class Branch(with_metaclass(BranchType, Leaf)):
     """Base resource class for a branch, extends Leaf."""
-    def __init__(self, _name, _parent, **attributes):
-        super(Branch, self).__init__(_name, _parent, **attributes)
-        self.__children__ = {}
 
+    @memoize
     def __getitem__(self, path):
         """Returns a cached child resource or returns a newly created one.
 
@@ -59,14 +59,10 @@ class Branch(with_metaclass(BranchType, Leaf)):
         A final attempt to load a resource is made by calling out to __load__.
         If this succeeds, the result is cached and returned.
         """
-        if path in self.__children__:
-            return self.__children__[path]
         if self._SUBPATHS is not None and path in self._SUBPATHS:
             resource_class, name = self._SUBPATHS[path]
-            resource = self.__children__[path] = resource_class(name, self)
-            return resource
-        resource = self.__children__[path] = self.__load__(path)
-        return resource
+            return resource_class(name, self)
+        return self.__load__(path)
 
     def __load__(self, path):
         """Dynamic resource loader for custom Branch classes.

--- a/kalpa/tests/test_kalpa.py
+++ b/kalpa/tests/test_kalpa.py
@@ -150,17 +150,6 @@ class TestBasicResource(object):
         with pytest.raises(KeyError):
             root['nonexistant']
 
-    def test_contains_false_before_access(self, basic_tree):
-        """Before accessing the leaf, the root has no child by that name."""
-        root = basic_tree['root']
-        assert 'leaf' not in root
-
-    def test_contains_true_after_access(self, basic_tree):
-        """After accessing the leaf, the root has a child by that name."""
-        root = basic_tree['root']
-        root['leaf']
-        assert 'leaf' in root
-
     def test_multiple_lookups_same_resource(self, basic_tree):
         """Looking up the same sub-resource twice gives the same instance."""
         root = basic_tree['root']

--- a/kalpa/util.py
+++ b/kalpa/util.py
@@ -1,0 +1,23 @@
+"""Kalpa helper utilities."""
+
+import functools
+
+
+def memoize(wrapped):
+    """Caches values returned by method, storing a cache on the instance.
+
+    The name cache is based on the function name, preventing accidental cache
+    sharing when multiple functions are memoized.
+    """
+    cache_name = wrapped.__name__.rstrip('_') + '__cache'
+
+    def decorator(inst, item):
+        try:
+            cache = getattr(inst, cache_name)
+        except AttributeError:
+            cache = {}
+            setattr(inst, cache_name, cache)
+        if item not in cache:
+            cache[item] = wrapped(inst, item)
+        return cache[item]
+    return functools.update_wrapper(decorator, wrapped)


### PR DESCRIPTION
* Removes the `__contains__` special method (and related tests) which checks presence of subpaths in resources, which isn't used by Pyramid
* Moves the caching of `__getitem__` responses to a separate decorator, separating concerns of loading and caching from eachother.