### PR TITLE
Simplify child resource creation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,10 +20,10 @@ Pyramid's traversal.
     class UserCollection(Branch):
         """User collection, for listings, or loading single users."""
 
-        def __load__(self, path):
+        def __load__(self, key):
             """Return child resource with requested user included."""
-            user = USERS[path]  # Load user or raise KeyError.
-            return self._sprout(key, user=user)
+            user = USERS[key]  # Load user or raise KeyError.
+            return self._child(key, user=user)
 
 
     @UserCollection.child_resource

--- a/kalpa/tests/test_kalpa.py
+++ b/kalpa/tests/test_kalpa.py
@@ -44,12 +44,12 @@ def branching_tree():
     @Root.attach('objects')
     class Collection(Branch):
         def __load__(self, path):
-            return self._sprout(path, fruit='apple', twice=path * 2)
+            return self._child(path, fruit='apple', twice=path * 2)
 
     @Root.attach('people')
     class People(Branch):
         def __load__(self, path):
-            return self._sprout_resource(Person, path, first=path[0].upper())
+            return self._child(Person, path, first=path[0].upper())
 
     @Collection.child_resource
     class Object(Branch):
@@ -85,7 +85,7 @@ def mixed_tree():
 
     class Root(Root):
         def __load__(self, path):
-            return self._sprout(path)
+            return self._child(path)
 
     @Root.attach('spam')
     @Root.attach('eggs')

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def contents(filename):
 
 setup(
     name='kalpa',
-    version='0.3',
+    version='0.4',
     packages=find_packages(),
     author='Elmer de Looff',
     author_email='elmer.delooff@gmail.com',


### PR DESCRIPTION
* Removes `_sprout` and `_sprout_resource` methods in favor of a single `_child` method that wraps both behaviors;
* Adds tests to verify correct working order, and the configuration error raised for the case where `_child()` gets called without a resource class and none has been configured.

This resolves #8.