### PR TITLE
Allow dict-like returns to create sub-resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,7 @@ Pyramid's traversal.
 
         def __load__(self, key):
             """Return child resource with requested user included."""
-            user = USERS[key]  # Load user or raise KeyError.
-            return self._child(key, user=user)
+            return {'user': USERS[key]}  # Load user or raise KeyError.
 
 
     @UserCollection.child_resource

--- a/kalpa/__init__.py
+++ b/kalpa/__init__.py
@@ -61,7 +61,10 @@ class Branch(with_metaclass(BranchType, Leaf)):
         if self._SUBPATHS is not None and path in self._SUBPATHS:
             resource_class, name = self._SUBPATHS[path]
             return resource_class(name, self)
-        return self.__load__(path)
+        resource = self.__load__(path)
+        if isinstance(resource, dict):
+            return self._create_branch(path, resource)
+        return resource
 
     def __load__(self, path):
         """Dynamic resource loader for custom Branch classes.
@@ -75,6 +78,13 @@ class Branch(with_metaclass(BranchType, Leaf)):
     def __repr__(self):
         """Returns a simple resources representation."""
         return '<{}>'.format(type(self).__name__)
+
+    def _create_branch(self, path, resource_params):
+        if self._CHILD_CLS is None:
+            raise ValueError(
+                'A child resource class should be defined when '
+                'using dict-like returns for __load__(). ')
+        return self._CHILD_CLS(path, self, **resource_params)
 
     def _child(self, *args, **attrs):
         """Returns a newly instantiated child resource.

--- a/kalpa/__init__.py
+++ b/kalpa/__init__.py
@@ -72,6 +72,10 @@ class Branch(with_metaclass(BranchType, Leaf)):
         """
         raise KeyError(path)
 
+    def __repr__(self):
+        """Returns a simple resources representation."""
+        return '<{}>'.format(type(self).__name__)
+
     def _child(self, *args, **attrs):
         """Returns a newly instantiated child resource.
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def contents(filename):
 
 setup(
     name='kalpa',
-    version='0.4',
+    version='0.4.1',
     packages=find_packages(),
     author='Elmer de Looff',
     author_email='elmer.delooff@gmail.com',


### PR DESCRIPTION
Instead of returning fully instantiated resource in `__load__`, this adds the support for dict-like returns. This cleans up the `__load__` usage for the majority of cases where only the properties of the returned resource are of concern, rather than the specific class used.

The behavior of `_child` can be simplified in a future version, changing the signature of the method to requiring a class to be specified, rather than the current `*args` signature with an optional class.