### PR TITLE
Changes __load__ to raise KeyError on None-returns.

### DIFF
--- a/kalpa/__init__.py
+++ b/kalpa/__init__.py
@@ -152,6 +152,8 @@ class Node(with_metaclass(NodeMeta, object)):
         if path in self._BRANCHES:
             return self._BRANCHES[path](self)
         resource = self.__load__(path)
+        if resource is None:
+            raise KeyError
         if isinstance(resource, dict):
             return self._child_from_dict(path, resource)
         return resource

--- a/kalpa/tests/base.py
+++ b/kalpa/tests/base.py
@@ -80,7 +80,7 @@ class People(Node):
     def __load__(self, name):
         if name in ADMINS:
             return self._child(Admin, name, **ADMINS[name])
-        return PEOPLE[name]
+        return PEOPLE.get(name)
 
 
 class Leaf(Node):

--- a/kalpa/tests/test_branch.py
+++ b/kalpa/tests/test_branch.py
@@ -103,7 +103,7 @@ def test_branch_load_cache(root, key_path):
 
 
 def test_branch_load_nonexisting(root):
-    """Retrieving a bad key fron a branching resource raises KeyError."""
+    """When __load__ returns a None value, this results in KeyError."""
     with pytest.raises(KeyError):
         root['people']['zenu']
 


### PR DESCRIPTION
This resolves #12 

* `Node.__getitem__` now raises KeyError if the return from `Node.__load__` is `None` (when loading fails);
* Updates the test for access to nonexisting paths to return None rather than raising KeyError explicitly.