### PR TITLE
Fixes Python 3 errors

### DIFF
--- a/kalpa/__init__.py
+++ b/kalpa/__init__.py
@@ -101,7 +101,7 @@ class NodeMeta(type):
         should_register = not attrs.pop('__abstract__', False)
         attributes = {'__child_cls__': None}
         branches = attributes['_BRANCHES'] = inherited_branches(bases)
-        for attr, value in attrs.iteritems():
+        for attr, value in iteritems(attrs):
             if isinstance(value, DeclaredBranch):
                 branches.update(value.generate_resources(attr))
             else:

--- a/kalpa/tests/test_branch.py
+++ b/kalpa/tests/test_branch.py
@@ -1,3 +1,4 @@
+import functools
 import itertools
 import operator
 
@@ -97,8 +98,8 @@ def test_branch_alternate_loading(root, user, node_class):
     ('objects', 'leaf'), ('people', 'charlie'), ('people', 'eve')])
 def test_branch_load_cache(root, key_path):
     """Retrieving the same object twice should provide the same one."""
-    first = reduce(operator.getitem, key_path, root)
-    second = reduce(operator.getitem, key_path, root)
+    first = functools.reduce(operator.getitem, key_path, root)
+    second = functools.reduce(operator.getitem, key_path, root)
     assert first is second
 
 

--- a/kalpa/tests/test_traversal.py
+++ b/kalpa/tests/test_traversal.py
@@ -1,5 +1,6 @@
 """Tests compatiblity and integration with Pyramid's traversal utlities."""
 
+import functools
 import operator
 
 import pytest
@@ -19,7 +20,7 @@ def test_find_root(root):
     ('/objects/apple/votes', ('objects', 'apple', 'votes'))])
 def test_find_resource(root, path, keys):
     """Resolving paths yields the expected resource."""
-    resource = reduce(operator.getitem, keys, root)
+    resource = functools.reduce(operator.getitem, keys, root)
     assert traversal.find_resource(root, path) == resource
 
 
@@ -28,7 +29,7 @@ def test_find_resource(root, path, keys):
     (('objects', 'pear', 'votes'), '/objects/pear/votes')])
 def test_resource_path(root, keys, path):
     """Resources generate the expected path."""
-    resource = reduce(operator.getitem, keys, root)
+    resource = functools.reduce(operator.getitem, keys, root)
     assert traversal.resource_path(resource) == path
 
 

--- a/kalpa/tests/test_utils.py
+++ b/kalpa/tests/test_utils.py
@@ -1,3 +1,4 @@
+import functools
 import operator
 
 import pytest
@@ -26,7 +27,7 @@ def test_util_lineage(root):
 def test_find_parent_by_class(root, selector, expected_key_path):
     """Finding a parent resource by its class."""
     alice = root['people']['alice']
-    expected = reduce(operator.getitem, expected_key_path, root)
+    expected = functools.reduce(operator.getitem, expected_key_path, root)
     assert parent_by_class(alice, selector) is expected
 
 
@@ -37,7 +38,7 @@ def test_find_parent_by_class(root, selector, expected_key_path):
 def test_find_parent_by_class_name(root, selector, expected_key_path):
     """Finding a parent resource by its class name."""
     alice = root['people']['alice']
-    expected = reduce(operator.getitem, expected_key_path, root)
+    expected = functools.reduce(operator.getitem, expected_key_path, root)
     assert parent_by_class(alice, selector) is expected
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def contents(filename):
 
 setup(
     name='kalpa',
-    version='0.5.0',
+    version='0.5.1',
     packages=find_packages(),
     author='Elmer de Looff',
     author_email='elmer.delooff@gmail.com',


### PR DESCRIPTION
* Fixes a glaring `AttributeError` in the metaclass for Node; replaces `.iteritems()` with `six.iteritems()`
* Imports `reduce` from `functools` package rather than accessing it as a builtin